### PR TITLE
Data pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# Data
+data/

--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,6 @@ dmypy.json
 
 # Data
 data/
+
+# Eg. for vocabs.
+temp/

--- a/data_pipeline/adjacency_mat.py
+++ b/data_pipeline/adjacency_mat.py
@@ -7,8 +7,7 @@ ROOT_LABEL = ':root'
 
 def get_concepts_to_triple_ids(g: penman.Graph):
   """
-  Extract a dictionary concept -> triple id (where the 
-  concept is instanced).
+  Extract a dictionary concept -> triple id (where the concept is instanced).
   """
   variables = g.variables()
   concepts_to_ids = {}

--- a/data_pipeline/adjacency_mat.py
+++ b/data_pipeline/adjacency_mat.py
@@ -27,7 +27,7 @@ def get_concepts_to_triple_ids(g: penman.Graph):
 def get_edges(g: penman.Graph, ordered_concept_ids: List[int], fake_root_id: int):
   variables = g.variables()
   edges = {}
-  # Add (src_var, trg_var) -> edge
+  # Add (src_var, trg_var) -> edge.
   for triple in g.triples:
     src = triple[0]
     edge_label = triple[1]
@@ -36,7 +36,7 @@ def get_edges(g: penman.Graph, ordered_concept_ids: List[int], fake_root_id: int
     # instance edge between the variable i and concept i.
     if src in variables and target in variables and src!=target:
       edges[(src, target)] = edge_label
-  # Add (src_var, constant) -> edge
+  # Add (src_var, constant) -> edge.
   for concept_pos in range(len(ordered_concept_ids)):
     penman_concept_id = ordered_concept_ids[concept_pos]
     if penman_concept_id != fake_root_id:

--- a/data_pipeline/adjacency_mat.py
+++ b/data_pipeline/adjacency_mat.py
@@ -1,0 +1,83 @@
+from typing import List
+import penman
+
+INSTANCE_ARC_LABEL = ":instance"
+ROOT_LABEL = ':root'
+
+
+def get_concepts_to_triple_ids(g: penman.Graph):
+  """
+  Extract a dictionary concept -> triple id (where the 
+  concept is instanced).
+  """
+  variables = g.variables()
+  concepts_to_ids = {}
+  for triple_id in range(len(g.triples)):
+    triple = g.triples[triple_id]
+    src = triple[0]
+    role_label = triple[1]
+    trgt = triple[2]
+    if role_label == INSTANCE_ARC_LABEL:
+      concepts_to_ids[src] = triple_id
+    if trgt not in variables:
+      concepts_to_ids[trgt] = triple_id
+  return concepts_to_ids
+
+
+def get_edges(g: penman.Graph, ordered_concept_ids: List[int], fake_root_id: int):
+  variables = g.variables()
+  edges = {}
+  # Add (src_var, trg_var) -> edge
+  for triple in g.triples:
+    src = triple[0]
+    edge_label = triple[1]
+    target = triple[2]
+    if src in variables and target in variables:
+      edges[(src, target)] = edge_label
+  # Add (src_var, constant) -> edge
+  for concept_pos in range(len(ordered_concept_ids)):
+    penman_concept_id = ordered_concept_ids[concept_pos]
+    if penman_concept_id != fake_root_id:
+      triple = g.triples[penman_concept_id]
+      src = triple[0]
+      edge_label = triple[1]
+      target = triple[2]
+      if edge_label != INSTANCE_ARC_LABEL:
+        # concept with no variable, src is parent.
+        edges[(src, target)] = edge_label
+  return edges
+
+
+def get_adjacency_mat(g: penman.Graph,
+                      ordered_concepts_ids: List[int],
+                      fake_root_id: int):
+  """
+  Construct an adjacency matrix from the penman graph representation of the AMR
+  and the list of ordered concepts (represented as penman triple ids).
+  Note: The ordered list of concepts contains on the first position a fake root
+  (will be added in the adjacency matrix so the amr top is encoded).
+
+  Returns
+    an adjacency matrix that contains
+      None: no edge
+      edge label (str): if edge
+  """
+  n = len(ordered_concepts_ids)
+  # 1. Construct (src_var, trgt_var/constant) -> edge label
+  edges = get_edges(g, ordered_concepts_ids, fake_root_id)
+  # 2. Construct concept -> triple id dict.
+  concepts_to_ids = get_concepts_to_triple_ids(g)
+  # 3. Construct triple_id -> concept pos dict.
+  triple_to_concept = {ordered_concepts_ids[c]: c for c in range(n)}
+  # 4. Construct adjacency matrix.
+  adj_mat = [[None for i in range(n)] for j in range(n)]
+  for edge, edge_label in edges.items():
+    src, trgt = edge
+    # Go from var/constant -> triple id -> ordered concept position.
+    src = triple_to_concept[concepts_to_ids[src]]
+    trgt = triple_to_concept[concepts_to_ids[trgt]]
+    adj_mat[src][trgt] = edge_label
+  # Add root.
+  top = triple_to_concept[concepts_to_ids[g.top]]
+  adj_mat[0][top] = ROOT_LABEL
+  return adj_mat

--- a/data_pipeline/adjacency_mat.py
+++ b/data_pipeline/adjacency_mat.py
@@ -32,7 +32,9 @@ def get_edges(g: penman.Graph, ordered_concept_ids: List[int], fake_root_id: int
     src = triple[0]
     edge_label = triple[1]
     target = triple[2]
-    if src in variables and target in variables:
+    # Need to check that src is different from trgt to not add the 
+    # instance edge between the variable i and concept i.
+    if src in variables and target in variables and src!=target:
       edges[(src, target)] = edge_label
   # Add (src_var, constant) -> edge
   for concept_pos in range(len(ordered_concept_ids)):
@@ -74,8 +76,12 @@ def get_adjacency_mat(g: penman.Graph,
   for edge, edge_label in edges.items():
     src, trgt = edge
     # Go from var/constant -> triple id -> ordered concept position.
-    src = triple_to_concept[concepts_to_ids[src]]
-    trgt = triple_to_concept[concepts_to_ids[trgt]]
+    src_triple_id = concepts_to_ids[src]
+    trgt_triple_id = concepts_to_ids[trgt]
+    src = triple_to_concept[src_triple_id]
+    trgt = triple_to_concept[trgt_triple_id]
+    # src = triple_to_concept[concepts_to_ids[src]]
+    # trgt = triple_to_concept[concepts_to_ids[trgt]]
     adj_mat[src][trgt] = edge_label
   # Add root.
   top = triple_to_concept[concepts_to_ids[g.top]]

--- a/data_pipeline/concepts.py
+++ b/data_pipeline/concepts.py
@@ -1,0 +1,91 @@
+from random import randrange
+from typing import List, Dict
+
+import penman
+from penman.graph import Triple
+
+# Extract from the AMR the nodes in inference order.
+# The nodes are represented by the position in the triples list (from the penman
+# amr representation).
+
+# The amr triples contain in the target part [2] the concepts, but not only (
+# they can contain variables). The triples are first filtered in order to only
+# have triples associated with the concepts.
+
+
+def get_concept_ids(g: penman.Graph) -> List[int]:
+  """
+  Constructs a list of concept ids.
+
+  Args:
+    g: amr graph (in penman library representation).
+  Returns:
+    A list of the triple ids (positions in the original triples list) for the
+    triples associated with concepts (that have a concept on the 3rd position). 
+  """
+  triples = g.triples
+  variables = [t[0] for t in triples]
+  variables = list(set(variables))
+  filtered_triples_ids = []
+  for triple_id in range(len(triples)):
+    t = triples[triple_id]
+    src = t[0]
+    trgt = t[2]
+    if trgt not in variables and src!=trgt:
+      filtered_triples_ids.append(triple_id)
+  return filtered_triples_ids
+
+
+def get_concepts_alignments(g: penman.Graph) -> Dict[int, List[int]]:
+  """
+  Construct a dictionary of concept id -> alignments for an AMR graph.
+
+  Args:
+    g: amr graph (in penman library representation).
+  Returns:
+    dictionary of concept_id -> alignments where the concept id is the position
+    in the g.triples list and alignments is a list of ints (token ids).
+  """
+  concept_ids = get_concept_ids(g)
+  node_alignments = alignments(g)
+  concepts_alignments = {}
+  for concept_id in concept_ids:
+    triple = g.triples[concept_id]
+    if triple in node_alignments.keys():
+      concepts_alignments[concept_id] = node_alignments[triple].indices
+    else:
+      concepts_alignments[concept_id] = []
+  return concepts_alignments
+
+
+def get_ordered_concepts_ids(g: penman.Graph, unalignment_tolerance = 0):
+  """
+  Constructs a list of ordered concepts.
+
+  Args:
+    g: amr graph (in penman library representation).
+    unalignment_tolerance: the percentage of concepts with no alignemnt info
+      allowed. If the amr has a larger percantage than allowed trhough this
+      parameter, the function returns None. If the amr has a non-zero percentage
+      of unaligned concepts but smaller than the tolerance, the unaligned
+      concepts are placed at random in the revariables = [t[0] for t in triples]
+  variables = list(set(variables))turn list.
+  Returns:
+    List of concepts ordered by inference order or None (where each concept is
+    represented by the triple id in the penman graph representation).
+  """
+  concepts_alignments = get_concepts_alignments(g)
+  concept_ids = concepts_alignments.keys()
+  no_concepts = len(concept_ids)
+  aligned_concepts = [c for c in concept_ids if len(concepts_alignments[c])>0]
+  unaligned_concepts = [c for c in concept_ids if c not in aligned_concepts]
+  no_unaligned_concepts = len(unaligned_concepts)
+  if no_unaligned_concepts/no_concepts > unalignment_tolerance:
+    return None
+  # Only use the first alignment for sorting (for now).
+  result = sorted(aligned_concepts, key = lambda c: concepts_alignments[c][0])
+  # Place unaligned concepts randomly.
+  for c in unaligned_concepts:
+    random_index = randrange(len(result))
+    result.insert(random_index, c)
+  return result

--- a/data_pipeline/concepts.py
+++ b/data_pipeline/concepts.py
@@ -3,7 +3,7 @@ from typing import List, Dict
 
 import penman
 from penman.graph import Triple
-
+from penman.surface import alignments
 # Extract from the AMR the nodes in inference order.
 # The nodes are represented by the position in the triples list (from the penman
 # amr representation).
@@ -30,8 +30,9 @@ def get_concept_ids(g: penman.Graph) -> List[int]:
   for triple_id in range(len(triples)):
     t = triples[triple_id]
     src = t[0]
+    rel = t[1]
     trgt = t[2]
-    if trgt not in variables and src!=trgt:
+    if trgt not in variables or rel == ':instance':
       filtered_triples_ids.append(triple_id)
   return filtered_triples_ids
 
@@ -86,6 +87,8 @@ def get_ordered_concepts_ids(g: penman.Graph, unalignment_tolerance = 0):
   result = sorted(aligned_concepts, key = lambda c: concepts_alignments[c][0])
   # Place unaligned concepts randomly.
   for c in unaligned_concepts:
-    random_index = randrange(len(result))
+    random_index = 0
+    if len(result) != 0:
+      random_index = randrange(len(result))
     result.insert(random_index, c)
   return result

--- a/data_pipeline/concepts.py
+++ b/data_pipeline/concepts.py
@@ -59,7 +59,7 @@ def get_ordered_concepts_ids(g: penman.Graph, unalignment_tolerance = 0):
   Args:
     g: amr graph (in penman library representation).
     unalignment_tolerance: the percentage of concepts with no alignemnt info
-      allowed. If the amr has a larger percantage than allowed trhough this
+      allowed. If the amr has a larger percantage than allowed through this
       parameter, the function returns None. If the amr has a non-zero percentage
       of unaligned concepts but smaller than the tolerance, the unaligned
       concepts are placed at random in the revariables = [t[0] for t in triples]

--- a/data_pipeline/concepts.py
+++ b/data_pipeline/concepts.py
@@ -4,13 +4,6 @@ from typing import List, Dict
 import penman
 from penman.graph import Triple
 from penman.surface import alignments
-# Extract from the AMR the nodes in inference order.
-# The nodes are represented by the position in the triples list (from the penman
-# amr representation).
-
-# The amr triples contain in the target part [2] the concepts, but not only (
-# they can contain variables). The triples are first filtered in order to only
-# have triples associated with the concepts.
 
 
 def get_concept_ids(g: penman.Graph) -> List[int]:

--- a/data_pipeline/concepts.py
+++ b/data_pipeline/concepts.py
@@ -2,7 +2,6 @@ from random import randrange
 from typing import List, Dict
 
 import penman
-from penman.graph import Triple
 from penman.surface import alignments
 
 
@@ -22,7 +21,6 @@ def get_concept_ids(g: penman.Graph) -> List[int]:
   filtered_triples_ids = []
   for triple_id in range(len(triples)):
     t = triples[triple_id]
-    src = t[0]
     rel = t[1]
     trgt = t[2]
     if trgt not in variables or rel == ':instance':

--- a/data_pipeline/data_reading.py
+++ b/data_pipeline/data_reading.py
@@ -3,6 +3,18 @@ import re
 import os
 import definitions
 
+"""Pattern for extracting the id, tokens, alignments and amr from an entry string.
+An entry example follows:
+# ::id bolt12_07_4800.1 ::amr-annotator SDL-AMR-09 ::preferred
+# ::tok Establishing Models in Industrial Innovation
+# ::alignments 0-1 1-1.1 2-1.1.1.r 3-1.1.1.1 4-1.1.1
+(e / establish-01~e.0 
+      :ARG1 (m / model~e.1 
+            :mod~e.2 (i / innovate-01~e.4 
+                  :ARG1 (i2 / industry~e.3))))
+"""
+AMR_PATTERN = r'# ::id(.*)\n# ::tok(.*)\n# ::alignments(.*)\n(?=\()(.*)'
+
 def extract_triples(path: str):
   """
   Return a list of (id, tokens, amr string) triples for an AMR data file.
@@ -16,8 +28,7 @@ def extract_triples(path: str):
   triples = []
   for data_block in data_blocks:
     # Use regex to extract the needed info from a text block.
-    pattern = r'# ::id(.*)\n# ::tok(.*)\n# ::alignments(.*)\n(?=\()(.*)'
-    match = re.search(pattern, data_block, re.DOTALL)
+    match = re.search(AMR_PATTERN, data_block, re.DOTALL)
     if match:
       id, sentence, alignments, amr = match.groups()
       triples.append((id, sentence, amr))

--- a/data_pipeline/data_reading.py
+++ b/data_pipeline/data_reading.py
@@ -1,0 +1,41 @@
+from typing import List
+import re
+import os
+import definitions
+
+def extract_triples(path: str):
+  """
+  Return a list of (id, tokens, amr string) triples for an AMR data file.
+  """
+  # Read file data into a string.
+  file = open(path,'r')
+  text = file.read()
+  file.close()
+  # Separate the data for each amr (id, token, alignemnts, amr).
+  data_blocks = text.split('\n\n')
+  triples = []
+  for data_block in data_blocks:
+    # Use regex to extract the needed info from a text block.
+    pattern = r'# ::id(.*)\n# ::tok(.*)\n# ::alignments(.*)\n(?=\()(.*)'
+    match = re.search(pattern, data_block, re.DOTALL)
+    if match:
+      id, sentence, alignments, amr = match.groups()
+      triples.append((id, sentence, amr))
+  return triples
+
+
+def get_paths(split: str, subsets: List[str]):
+  """
+  Returns a list of paths.
+  Args:
+    split: one of 'training', 'dev', 'test'
+    subsets: list of amr data subsets (eg. 'bolt', 'dfa')
+  """
+  path = os.path.join(definitions.PROJECT_ROOT_DIR,
+                      definitions.DATA_PATH,
+                      split,
+                      definitions.FILE_FORMAT)
+  paths = []
+  for subset in subsets:
+    paths.append(path.format(split, subset))
+  return paths

--- a/data_pipeline/dataset.py
+++ b/data_pipeline/dataset.py
@@ -1,7 +1,6 @@
 from typing import List
 import torch
 from torch.utils.data import Dataset, DataLoader
-import torchtext
 
 from torch.nn.functional import pad as torch_pad
 import penman
@@ -99,7 +98,6 @@ if __name__ == "__main__":
   
   dataloader = DataLoader(dataset, batch_size=3, collate_fn=collate_fn)
 
-  print('Created `torchtext_train_dataloader` with %d batches!'%len(dataloader))
   i = 0
   for batch in dataloader:
     if i == 2:

--- a/data_pipeline/dataset.py
+++ b/data_pipeline/dataset.py
@@ -1,0 +1,109 @@
+from typing import List
+import torch
+from torch.utils.data import Dataset, DataLoader
+import torchtext
+
+from torch.nn.functional import pad as torch_pad
+import penman
+from penman.models import noop
+from data_pipeline.training_entry import TrainingEntry
+from data_pipeline.data_reading import extract_triples, get_paths
+
+PAD = '<pad>' 
+
+class AMRDataset(Dataset):
+  """
+  Dataset of sentence - amr entries, where the amrs are represented as a list
+  of concepts and adjacency matrix.
+  """
+
+  def __init__(self, paths: List[str]):
+    super(AMRDataset, self).__init__()
+    self.token_vocab: Dict[str, int] = {PAD: 0}
+    self.concept_vocab: Dict[str, int] = {PAD: 0}
+    self.relation_vocab: Dict[str, int] = {None: 0}
+    self.sentences_list= []
+    self.concepts_list = []
+    self.adj_mat_list = []
+    for path in paths:
+      triples = extract_triples(path)
+      for triple in triples:
+        id, sentence, amr_str = triple
+        amr_penman_graph = penman.decode(amr_str, model=noop.model)
+        training_entry = TrainingEntry(
+          sentence=sentence.split(),
+          g=amr_penman_graph,
+          unalignment_tolerance=1)
+        # Update vocabularies.
+        self.token_vocab, self.concept_vocab, self.relation_vocab = \
+          training_entry.update_vocabs(self.token_vocab,
+                                       self.concept_vocab,
+                                       self.relation_vocab)
+        # Process the training entry (str -> vocab ids).
+        sentence, concepts, adj_mat = training_entry.process(
+          self.token_vocab, self.concept_vocab, self.relation_vocab)
+        # Convert to pytorch tensors.
+        #TODO: should I use pytorch or numpy tensors?
+        sentence = torch.tensor(sentence, dtype=torch.int)
+        concepts = torch.tensor(concepts, dtype=torch.int)
+        adj_mat = torch.tensor(adj_mat, dtype=torch.int)
+        # Collect the data.
+        self.sentences_list.append(sentence)
+        self.concepts_list.append(concepts)
+        self.adj_mat_list.append(adj_mat)
+
+  def __len__(self):
+    return len(self.sentences_list)
+
+  def __getitem__(self, item):
+    return self.sentences_list[item], self.concepts_list[item],  self.adj_mat_list[item]
+
+def collate_fn(batch):
+  batch_sentences = []
+  batch_concepts = []
+  batch_adj_mats = []
+  for entry in batch:
+    sentence, concepts, adj_mat = entry
+    batch_sentences.append(sentence)
+    batch_concepts.append(concepts)
+    batch_adj_mats.append(adj_mat)
+  # Get max lengths for padding.
+  max_sen_len = max([len(s) for s in batch_sentences])
+  max_concepts_len = max([len(s) for s in batch_concepts])
+  max_adj_mat_size = max([len(s) for s in batch_adj_mats])
+  # Pad sentences.
+  padded_sentences = [
+    torch_pad(s, (0, max_sen_len - len(s))) for s in batch_sentences]
+  # Pad concepts
+  padded_concepts = [
+    torch_pad(c, (0, max_concepts_len - len(c))) for c in batch_concepts]
+  # Pad adj matrices (pad on both dimensions).
+  padded_adj_mats = []
+  for adj_mat in batch_adj_mats:
+    # Since it's a square matrix, the padding is the same on both dimensions.
+    pad_size = max_adj_mat_size - len(adj_mat[0])
+    padded_adj_mats.append(torch_pad(adj_mat, (0, pad_size, 0, pad_size)))
+  new_batch = {
+    'sentence': torch.stack(padded_sentences),
+    'concepts': torch.stack(padded_concepts),
+    'adj_mat': torch.stack(padded_adj_mats)
+  }
+  return new_batch
+
+#TODO: remove this and add tests.
+if __name__ == "__main__":
+  subsets = ['bolt', 'cctv', 'dfa', 'dfb', 'guidelines',
+             'mt09sdl', 'proxy', 'wb', 'xinhua']
+  paths = get_paths('training', subsets)
+  dataset = AMRDataset(paths)
+  
+  dataloader = DataLoader(dataset, batch_size=3, collate_fn=collate_fn)
+
+  print('Created `torchtext_train_dataloader` with %d batches!'%len(dataloader))
+  i = 0
+  for batch in dataloader:
+    if i == 2:
+      break
+    i+=1
+    print('Batch ',i)
+    print(batch)

--- a/data_pipeline/training_entry.py
+++ b/data_pipeline/training_entry.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Dict
 import penman
 from data_pipeline.concepts import get_ordered_concepts_ids
 from data_pipeline.adjacency_mat import get_adjacency_mat
@@ -8,14 +8,25 @@ ROOT = 'root'
 
 class TrainingEntry():
   
-  def __init__(self, concepts: List[str], adjacency_mat: List[List[str]]):
+  def __init__(self,
+    sentence: List[str],
+    g: penman.Graph,
+    unalignment_tolerance: float = 0):
+    "Create training entry with sentence and AMR."
+    concepts, adj_mat = TrainingEntry.construct_from_penman(g,
+      unalignment_tolerance)
+    if concepts is None:
+      return None
+    self.sentence = sentence
     self.concepts = concepts
-    self.adjacency_mat = adjacency_mat
+    self.adjacency_mat = adj_mat
 
   @staticmethod
   def construct_from_penman(g: penman.Graph, unalignment_tolerance: float):
     # Get ordered concepts.
     ordered_concept_ids = get_ordered_concepts_ids(g, unalignment_tolerance)
+    if ordered_concept_ids is None:
+      return None, None
     ordered_concepts = [g.triples[c_id][2] for c_id in ordered_concept_ids]
     # Add fake root.
     ordered_concept_ids.insert(0, ROOT_ID)
@@ -23,4 +34,61 @@ class TrainingEntry():
     # Get adjacency matrix.
     adj_mat = get_adjacency_mat(g, ordered_concept_ids, ROOT_ID)
     # Return training entry.
-    return TrainingEntry(ordered_concepts, adj_mat)
+    return ordered_concepts, adj_mat
+
+  def update_vocabs(self,
+                    token_vocab: Dict[str, int],
+                    concept_vocab: Dict[str, int],
+                    relation_vocab: Dict[str, int]):
+    """
+    Update the three vocabularies with elements from the training entry.
+    Args:
+      token_vocab: Vocabulary of sentence tokens.
+      concept_vocab: Vocabulary of concepts.
+      relation_vocab: Vocabulary of arc relations.
+    Returns:
+      A tuple of the updated vocabularies:
+      (token_vocab, concept_vocab, relation_vocab).
+    """
+    # Update token vocab.
+    for token in self.sentence:
+      if token not in token_vocab.keys():
+        token_vocab.update({token: len(token_vocab.keys())})
+    # Update concept vocab.
+    for concept in self.concepts:
+      if concept not in concept_vocab.keys():
+        concept_vocab.update({concept: len(concept_vocab.keys())})
+    # Update relation vocab.
+    for row in self.adjacency_mat:
+      for relation in row:
+        if relation != None and relation not in relation_vocab.keys():
+          relation_vocab.update({relation: len(relation_vocab.keys())})
+    return token_vocab, concept_vocab, relation_vocab
+
+  def process(self,
+              token_vocab: Dict[str, int],
+              concept_vocab: Dict[str, int],
+              relation_vocab: Dict[str, int]):
+    """
+    Processes the train entry into lists of integeres that can be easily converted
+    into tensors. For the adjacency matrix 0 will be used in case the relation
+    does not exist (is None).
+    Args:
+      token_vocab: Vocabulary of sentence tokens.
+      concept_vocab: Vocabulary of concepts.
+      relation_vocab: Vocabulary of arc relations.
+    Returns a tuple of:
+      sentece: List of token indices.
+      concepts: List of concept indices.
+      adj_mat: Adjacency matrix which contains arc labels indices in the vocab.
+    """
+    # Process sentence.
+    processed_sentence = [token_vocab[t] for t in self.sentence]
+    # Process concepts.
+    processed_concepts = [concept_vocab[c] for c in self.concepts]
+    # Process adjacency matrix.
+    processed_adj_mat = []
+    for row in self.adjacency_mat:
+      processed_row = [0 if r is None else relation_vocab[r] for r in row]
+      processed_adj_mat.append(processed_row)
+    return processed_sentence, processed_concepts, processed_adj_mat

--- a/data_pipeline/training_entry.py
+++ b/data_pipeline/training_entry.py
@@ -36,39 +36,22 @@ class TrainingEntry():
     # Return training entry.
     return ordered_concepts, adj_mat
 
-  def update_vocabs(self,
-                    token_vocab: Dict[str, int],
-                    concept_vocab: Dict[str, int],
-                    relation_vocab: Dict[str, int]):
+  def get_labels(self):
+    """Returns the tokens, concepts and relations in a training entry.
     """
-    Update the three vocabularies with elements from the training entry.
-    Args:
-      token_vocab: Vocabulary of sentence tokens.
-      concept_vocab: Vocabulary of concepts.
-      relation_vocab: Vocabulary of arc relations.
-    Returns:
-      A tuple of the updated vocabularies:
-      (token_vocab, concept_vocab, relation_vocab).
-    """
-    # Update token vocab.
-    for token in self.sentence:
-      if token not in token_vocab.keys():
-        token_vocab.update({token: len(token_vocab.keys())})
-    # Update concept vocab.
-    for concept in self.concepts:
-      if concept not in concept_vocab.keys():
-        concept_vocab.update({concept: len(concept_vocab.keys())})
-    # Update relation vocab.
+    tokens = self.sentence
+    concepts = self.concepts
+    relations = []
     for row in self.adjacency_mat:
       for relation in row:
-        if relation != None and relation not in relation_vocab.keys():
-          relation_vocab.update({relation: len(relation_vocab.keys())})
-    return token_vocab, concept_vocab, relation_vocab
+        if relation != None:
+          relations.append(relation)
+    return tokens, concepts, relations
 
-  def process(self,
-              token_vocab: Dict[str, int],
-              concept_vocab: Dict[str, int],
-              relation_vocab: Dict[str, int]):
+  def numericalize(self,
+                   token_vocab: Dict[str, int],
+                   concept_vocab: Dict[str, int],
+                   relation_vocab: Dict[str, int]):
     """
     Processes the train entry into lists of integeres that can be easily converted
     into tensors. For the adjacency matrix 0 will be used in case the relation

--- a/data_pipeline/training_entry.py
+++ b/data_pipeline/training_entry.py
@@ -1,0 +1,26 @@
+from typing import List
+import penman
+from data_pipeline.concepts import get_ordered_concepts_ids
+from data_pipeline.adjacency_mat import get_adjacency_mat
+
+ROOT_ID = -1
+ROOT = 'root'
+
+class TrainingEntry():
+  
+  def __init__(self, concepts: List[str], adjacency_mat: List[List[str]]):
+    self.concepts = concepts
+    self.adjacency_mat = adjacency_mat
+
+  @staticmethod
+  def construct_from_penman(g: penman.Graph, unalignment_tolerance: float):
+    # Get ordered concepts.
+    ordered_concept_ids = get_ordered_concepts_ids(g, unalignment_tolerance)
+    ordered_concepts = [g.triples[c_id][2] for c_id in ordered_concept_ids]
+    # Add fake root.
+    ordered_concept_ids.insert(0, ROOT_ID)
+    ordered_concepts.insert(0, ROOT)
+    # Get adjacency matrix.
+    adj_mat = get_adjacency_mat(g, ordered_concept_ids, ROOT_ID)
+    # Return training entry.
+    return TrainingEntry(ordered_concepts, adj_mat)

--- a/data_pipeline/vocab.py
+++ b/data_pipeline/vocab.py
@@ -1,0 +1,144 @@
+from typing import List, Tuple, Dict
+from collections import Counter
+import os
+import pickle
+
+import penman
+from penman.models import noop
+
+import definitions
+from data_pipeline.data_reading import extract_triples, get_paths
+from data_pipeline.training_entry import TrainingEntry
+
+VOCAB_PATH = 'temp/vocabs'
+TOKENS_CACHE_FILE = 'tokens.pickle'
+CONCEPTS_CACHE_FILE = 'concepts.pickle'
+RELATIONS_CACHE_FILE = 'relations.pickle'
+
+def build_vocab(words: List[str], special_words:List[str], min_frequency: int):
+  words_counter = Counter(words)
+  words_and_freq = sorted(
+    words_counter.items(), key=lambda pair: pair[1], reverse=True)
+  # Filter out words with freq < min frequency.
+  filtered_words_and_freq = [
+    pair for pair in words_and_freq if pair[1] >= min_frequency]
+  filtered_words = [wf[0] for wf in filtered_words_and_freq]
+  vocab_words = special_words + filtered_words
+  vocab = {word: i for i, word in enumerate(vocab_words)}
+  return vocab
+  
+def get_cache_paths():
+  cache_dir = os.path.join(definitions.PROJECT_ROOT_DIR, VOCAB_PATH)
+  cache_files = [TOKENS_CACHE_FILE, CONCEPTS_CACHE_FILE, RELATIONS_CACHE_FILE]
+  cache_paths = [os.path.join(cache_dir, f) for f in cache_files]
+  return cache_paths
+
+def read_cached_vocabs():
+  """
+  Returns:
+    The 3 cached vocabs (tokens, concepts, relations) or None if nothing cached.
+  """
+  cache_paths = get_cache_paths()
+  vocabs = []
+  for cache_path in cache_paths:
+    if os.path.isfile(cache_path):
+      with open(cache_path, 'rb') as vocab_file:
+        vocab = pickle.load(vocab_file)
+        vocabs.append(vocab)
+    else:
+      return None
+  return vocabs[0], vocabs[1], vocabs[2]
+
+def cache_vocabs(token_vocab: Dict[str, int],
+                 concept_vocab: Dict[str, int],
+                 relation_vocab: Dict[str, int]):
+  cache_dir = os.path.join(definitions.PROJECT_ROOT_DIR, VOCAB_PATH)
+  if not os.path.exists(cache_dir):
+    os.makedirs(cache_dir)
+    return None
+  cache_paths = get_cache_paths()
+  vocabs = [token_vocab, concept_vocab, relation_vocab]
+  for i in range(len(cache_paths)):
+    with open(cache_paths[i], 'wb') as vocab_file:
+      pickle.dump(vocabs[i], vocab_file)
+
+def build_vocabs(paths: List[str],
+                 special_words: Tuple[List[str], List[str], List[str]],
+                 min_frequencies: Tuple[int, int, int]):
+  """
+  Builds the 3 vocabularies. The vocabularies are cached and constructed again
+  only if the caching doesn't exist.
+  """
+  #TODO: control caching though param.
+  vocabs = read_cached_vocabs()
+  if vocabs is not None:
+    return vocabs
+  # Unpack tuples.
+  special_tokens, special_concepts, special_relations = special_words
+  min_freq_tokens, min_freq_concepts, min_freq_relations = min_frequencies
+  # Extract all the words.
+  all_tokens = []
+  all_concepts = []
+  all_relations = []
+  for path in paths:
+    triples = extract_triples(path)
+    for triple in triples:
+      id, sentence, amr_str = triple
+      amr_penman_graph = penman.decode(amr_str, model=noop.model)
+      training_entry = TrainingEntry(
+        sentence=sentence.split(),
+        g=amr_penman_graph,
+        unalignment_tolerance=1)
+      tokens, concepts, relations = training_entry.get_labels()
+      all_tokens += tokens
+      all_concepts += concepts
+      all_relations += relations
+  # Extract the vocabs.
+  token_vocab = build_vocab(all_tokens, special_tokens, min_freq_tokens)
+  concept_vocab = build_vocab(all_concepts, special_concepts, min_freq_concepts)
+  relation_vocab = build_vocab(all_relations, special_relations, min_freq_relations)
+  # Cache the vocabs.
+  cache_vocabs(token_vocab, concept_vocab, relation_vocab)
+  return token_vocab, concept_vocab, relation_vocab
+
+
+class Vocabs():
+
+  def __init__(self,
+               paths: List[str],
+               unkown_special_word: str,
+               special_words: Tuple[List[str], List[str], List[str]],
+               min_frequencies: Tuple[int, int, int]):
+    """
+    Args:
+      paths: Amr data file paths.
+      unkown_special_word: Unknown special word.
+      special_words: Tuple of special words (for sentence tokens, for concepts
+        and for relations). Each list contains special words like PAD or UNK
+        (these are addded at the begining of the vocab, with PAD usually at
+        index 0).
+      min_frequencies: Tuple of min frequencies for tokens, concepts and
+        relations. If the words have a frequency < than the given frequency,
+        they are not added to the vocab.
+    """
+    self.unkown_special_word = unkown_special_word
+    token_vocab, concept_vocab, relation_vocab = build_vocabs(
+      paths, special_words, min_frequencies)
+    self.token_vocab = token_vocab
+    self.concept_vocab = concept_vocab
+    self.relation_vocab = relation_vocab
+
+  def get_token_idx(self, token: str):
+    if token in self.token_vocab.keys():
+      return self.token_vocab[token]
+    return self.token_vocab[self.unkown_special_word]
+
+  def get_concept_idx(self, concept: str):
+    if concept in self.concept_vocab.keys():
+      return self.concept_vocab[token]
+    return self.concept_vocab[self.unkown_special_word]
+
+  def get_relation_idx(self, token: str):
+    if token in self.relation_vocab.keys():
+      return self.relation_vocab[token]
+    return self.relation_vocab[self.unkown_special_word]

--- a/definitions.py
+++ b/definitions.py
@@ -1,0 +1,6 @@
+import os
+
+PROJECT_ROOT_DIR = os.path.dirname(os.path.abspath(__file__))
+
+DATA_PATH = 'data/LDC2016E25_DEFT_Phase_2_AMR_Annotation_R2/data/alignments/split'
+FILE_FORMAT = 'deft-p2-amr-r2-alignments-{0}-{1}.txt'

--- a/integration_tests/data_pipeline/training_entry_test.py
+++ b/integration_tests/data_pipeline/training_entry_test.py
@@ -1,0 +1,59 @@
+from absl.testing import absltest
+import penman
+from penman.models import noop
+from penman.surface import (
+    Alignment,
+    RoleAlignment
+)
+from data_pipeline.training_entry import TrainingEntry
+
+class TrainingEntryTest(absltest.TestCase):
+
+  def test_training_entry_amr_with_i(self):
+    sentence = 'Am I being foolish in doing this ?'
+    sentence = sentence.split()
+    amr_str = """
+    (f / foolish~e.3 :mode~e.7 interrogative~e.7 
+      :domain~e.0,2 (i / i~e.1) 
+      :condition~e.4 (d / do-02~e.5 
+            :ARG0 i 
+            :ARG1 (t / this~e.6)))
+    """
+    g = penman.decode(amr_str, model=noop.model)
+    training_entry = TrainingEntry(sentence, g)
+    #TODO: test training entry contents.
+    self.assertNotEqual(training_entry, None)
+
+  def test_training_entry_with_i_2(self):
+    sentence = 'Ultimately , it will reveal its wolf nature , and I hope the sheep will not be fooled by it .'
+    amr_str = """
+    (a / and~e.9 
+      :op1 (r / reveal-01~e.4 
+            :ARG0 (i / it~e.2) 
+            :ARG1 (n / nature~e.7 
+                  :mod (w / wolf~e.6) 
+                  :poss~e.5 i~e.5) 
+            :time (u / ultimate~e.0)) 
+      :op2 (h / hope-01~e.11 
+            :ARG0 (i2 / i~e.10) 
+            :ARG1 (f / fool-01~e.17 :polarity~e.15 -~e.15 
+                  :ARG0~e.18 i~e.19 
+                  :ARG1 (s / sheep~e.13))))
+    """
+    sentence = sentence.split()
+    g = penman.decode(amr_str)
+    training_entry = TrainingEntry(sentence, g)
+    #TODO: test training entry contents.
+    self.assertNotEqual(training_entry, None)
+
+  def test_training_entry_amr_one_node(self):
+    sentence = '%pw'
+    amr_str = """
+    (t / thing)
+    """
+    g = penman.decode(amr_str)
+    training_entry = TrainingEntry(sentence, g, unalignment_tolerance=1)
+    self.assertNotEqual(training_entry, None)
+
+if __name__ == '__main__':
+  absltest.main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+penman
+absl-py

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 penman
 absl-py
+torch

--- a/tests/data_pipeline/training_entry_test.py
+++ b/tests/data_pipeline/training_entry_test.py
@@ -106,7 +106,7 @@ class TrainingEntryTest(absltest.TestCase):
     training_entry = TrainingEntry(
       [], g, unalignment_tolerance=0)
     expected_concepts = [
-      'root', 'this', 'issue-02', 'recommend-01', 'attract-01', 'close-10', 'attend-02', 'economist'
+      'root', 'this', 'issue-02', 'recommend-01', 'attract-01', 'close-10','attend-02', 'economist'
     ]
     expected_mat = [
       [None, None, None, ':root', None, None, None, None],

--- a/tests/data_pipeline/training_entry_test.py
+++ b/tests/data_pipeline/training_entry_test.py
@@ -1,0 +1,228 @@
+from absl.testing import absltest
+import penman
+from penman.models import noop
+from penman.surface import (
+    Alignment,
+    RoleAlignment
+)
+from data_pipeline.training_entry import TrainingEntry
+
+"""
+Tests for data_pipeline/training_entry.py
+Run from project dir with 'python -m tests.data_pipeline.training_entry_test'
+"""
+
+class TrainingEntryTest(absltest.TestCase):
+
+  def test_construct_from_penman_simple_amr(self):
+    """
+    # ::id bolt12_07_4800.1
+    # ::tok Establishing Models in Industrial Innovation
+    (e / establish-01~e.0 
+          :ARG1 (m / model~e.1 
+                :mod~e.2 (i / innovate-01~e.4 
+                      :ARG1 (i2 / industry~e.3))))
+    """
+    triples = [
+      ('e', ':instance', 'establish-01'),
+      ('e', ':ARG1', 'm'),
+      ('m', ':instance', 'model'),
+      ('m', ':mod', 'i'),
+      ('i', ':instance', 'innovate-01'),
+      ('i', ':ARG1', 'i2'),
+      ('i2', ':instance', 'industry')
+    ]
+    top = 'e'
+    epidata = {
+      ('e', ':instance', 'establish-01'): [Alignment((0,), prefix='e.')],
+      ('e', ':ARG1', 'm'): [],
+      ('m', ':instance', 'model'): [Alignment((1,), prefix='e.')],
+      ('m', ':mod', 'i'): [],
+      ('i', ':instance', 'innovate-01'): [Alignment((4,), prefix='e.')],
+      ('i', ':ARG1', 'i2'): [],
+      ('i2', ':instance', 'industry'): [Alignment((3,), prefix='e.')]
+    }
+    g = penman.Graph(triples, top, epidata)
+    training_entry = TrainingEntry.construct_from_penman(
+      g, unalignment_tolerance=0)
+    expected_concepts = [
+      'root', 'establish-01', 'model', 'industry', 'innovate-01']
+    expected_mat = [
+      [None, ':root', None, None, None],
+      [None, None, ':ARG1', None, None],
+      [None, None, None, None, ':mod'],
+      [None, None, None, None, None],
+      [None, None, None, ':ARG1', None]
+    ]
+    self.assertEqual(training_entry.concepts, expected_concepts)
+    self.assertEqual(training_entry.adjacency_mat, expected_mat)
+
+  def test_construct_from_penman_reentrancy_amr(self):
+    """
+    # ::tok This issue should attract the close attention of economists .
+    (r / recommend-01~e.2 
+          :ARG1 (a / attract-01~e.3 
+                :ARG0 (i / issue-02~e.1 
+                      :mod (t / this~e.0)) 
+                :ARG1 (a2 / attend-02~e.6 
+                      :ARG0~e.7 (e / economist~e.8) 
+                      :ARG1 i 
+                      :ARG1-of (c / close-10~e.5))))
+    """
+    triples = [
+      ('r', ':instance', 'recommend-01'),
+      ('r', ':ARG1', 'a'),
+      ('a', ':instance', 'attract-01'),
+      ('a', ':ARG0', 'i'),
+      ('a', ':ARG1', 'a2'),
+      ('i', ':instance', 'issue-02'),
+      ('i', ':mod', 't'),
+      ('t', ':instance', 'this'),
+      ('a2', ':instance', 'attend-02'),
+      ('a2', ':ARG0', 'e'),
+      ('e', ':instance', 'economist'),
+      ('a2', ':ARG1', 'i'),
+      ('a2', ':ARG1-of', 'c'),
+      ('c', ':instance', 'close-10')
+    ]
+    top = 'r'
+    epidata = {
+      ('r', ':instance', 'recommend-01'): [Alignment((2,), prefix='e.')],
+      ('r', ':ARG1', 'a'): [],
+      ('a', ':instance', 'attract-01'): [Alignment((3,), prefix='e.')],
+      ('a', ':ARG0', 'i'): [],
+      ('a', ':ARG1', 'a2'): [],
+      ('i', ':instance', 'issue-02'): [Alignment((1,), prefix='e.')],
+      ('i', ':mod', 't'): [],
+      ('t', ':instance', 'this'): [Alignment((0,), prefix='e.')],
+      ('a2', ':instance', 'attend-02'): [Alignment((6,), prefix='e.')],
+      ('a2', ':ARG0', 'e'): [],
+      ('e', ':instance', 'economist'): [Alignment((8,), prefix='e.')],
+      ('a2', ':ARG1', 'i'): [],
+      ('a2', ':ARG1-of', 'c'): [],
+      ('c', ':instance', 'close-10'): [Alignment((5,), prefix='e.')]
+    }
+    g = penman.Graph(triples, top, epidata)
+    training_entry = TrainingEntry.construct_from_penman(
+      g, unalignment_tolerance=0)
+    expected_concepts = [
+      'root', 'this', 'issue-02', 'recommend-01', 'attract-01', 'close-10', 'attend-02', 'economist'
+    ]
+    expected_mat = [
+      [None, None, None, ':root', None, None, None, None],
+      [None, None, None, None, None, None, None, None],
+      [None, ':mod', None, None, None, None, None, None],
+      [None, None, None, None, ':ARG1', None, None, None],
+      [None, None, ':ARG0', None, None, None, ':ARG1', None],
+      [None, None, None, None, None, None, None, None],
+      [None, None, ':ARG1', None, None, ':ARG1-of', None, ':ARG0'],
+      [None, None, None, None, None, None, None, None]
+    ]
+    self.assertEqual(training_entry.concepts, expected_concepts)
+    self.assertEqual(training_entry.adjacency_mat, expected_mat)
+
+  def test_construct_from_penman_complex_amr(self):
+    """
+    Test for the amr:
+    What is more they are considered traitors of China , which is a fact of
+    cultural tyranny in the cloak of nationalism and patriotism .
+    
+    (c / consider-01~e.5 
+      :ARG1 (p2 / person~e.6 
+            :domain~e.1,4,11 (t2 / they~e.3) 
+            :ARG0-of~e.6 (b / betray-01~e.6 
+                  :ARG1~e.7 (c2 / country~e.8 :wiki "China"~e.8 
+                        :name (n2 / name~e.8 :op1 "China"~e.8)))) 
+      :mod (m / more~e.2) 
+      :mod (t4 / tyrannize-01~e.16
+            :ARG2 (c3 / culture~e.15) 
+            :ARG1-of (c4 / cloak-01~e.19 
+                  :ARG2~e.20 (a / and~e.22 
+                        :op1 (n / nationalism~e.21) 
+                        :op2 (p / patriotism~e.23)))))"""
+    top = 'c'
+    triples = [
+      ('c', ':instance', 'consider-01'),
+      ('c', ':ARG1', 'p2'),
+      ('p2', ':instance', 'person'),
+      ('p2', ':domain', 't2'),
+      ('t2', ':instance', 'they'),
+      ('p2', ':ARG0-of', 'b'),
+      ('b', ':instance', 'betray-01'),
+      ('b', ':ARG1', 'c2'),
+      ('c2', ':instance', 'country'),
+      ('c2', ':wiki', '"China"'),
+      ('c2', ':name', 'n2'),
+      ('n2', ':instance', 'name'),
+      ('n2', ':op1', '"China"'),
+      ('c', ':mod', 'm'),
+      ('m', ':instance', 'more'),
+      ('c', ':mod', 't4'),
+      ('t4', ':instance', 'tyrannize-01'),
+      ('t4', ':ARG2', 'c3'),
+      ('c3', ':instance', 'culture'),
+      ('t4', ':ARG1-of', 'c4'),
+      ('c4', ':instance', 'cloak-01'),
+      ('c4', ':ARG2', 'a'),
+      ('a', ':instance', 'and'),
+      ('a', ':op1', 'n'),
+      ('n', ':instance', 'nationalism'),
+      ('a', ':op2', 'p'),
+      ('p', ':instance', 'patriotism')]
+    epidata = {
+      ('c', ':instance', 'consider-01'): [Alignment((5,), prefix='e.')],
+      ('p2', ':instance', 'person'): [Alignment((6,), prefix='e.')],
+      ('p2', ':domain', 't2'): [RoleAlignment((1, 4, 11), prefix='e.')],
+      ('t2', ':instance', 'they'): [Alignment((3,), prefix='e.')],
+      ('p2', ':ARG0-of', 'b'): [RoleAlignment((6,), prefix='e.')],
+      ('b', ':instance', 'betray-01'): [Alignment((6,), prefix='e.')],
+      ('b', ':ARG1', 'c2'): [RoleAlignment((7,), prefix='e.')],
+      ('c2', ':instance', 'country'): [Alignment((8,), prefix='e.')],
+      ('c2', ':wiki', '"China"'): [Alignment((8,), prefix='e.')],
+      ('c2', ':name', 'n2'): [Alignment((8,), prefix='e.')],
+      ('n2', ':instance', 'name'): [Alignment((8,), prefix='e.')],
+      ('n2', ':op1', '"China"'): [Alignment((8,), prefix='e.')],
+      ('c', ':mod', 'm'): [],
+      ('m', ':instance', 'more'): [Alignment((2,), prefix='e.')],
+      ('c', ':mod', 't4'): [],
+      ('t4', ':instance', 'tyrannize-01'): [Alignment((16,), prefix='e.')],
+      ('t4', ':ARG2', 'c3'): [],
+      ('c3', ':instance', 'culture'): [Alignment((15,), prefix='e.')],
+      ('t4', ':ARG1-of', 'c4'): [],
+      ('c4', ':instance', 'cloak-01'): [Alignment((19,), prefix='e.')],
+      ('c4', ':ARG2', 'a'): [RoleAlignment((20,), prefix='e.')],
+      ('a', ':instance', 'and'): [Alignment((22,), prefix='e.')],
+      ('a', ':op1', 'n'): [],
+      ('n', ':instance', 'nationalism'): [Alignment((21,), prefix='e.')],
+      ('a', ':op2', 'p'): [],
+      ('p', ':instance', 'patriotism'): [Alignment((23,), prefix='e.')]}
+    g = penman.Graph(triples, top, epidata)
+    training_entry = TrainingEntry.construct_from_penman(
+      g, unalignment_tolerance=1)
+    expected_concepts = [
+      'root', 'more', 'they', 'consider-01', 'person', 'betray-01', 'country',
+      '"China"', 'name', '"China"', 'culture', 'tyrannize-01', 'cloak-01',
+      'nationalism', 'and', 'patriotism']
+    expected_mat = [
+      [None, None, None, ':root', None, None, None, None, None, None, None, None, None, None, None, None],
+      [None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None],
+      [None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None],
+      [None, ':mod', None, None, ':ARG1', None, None, None, None, None, None, ':mod', None, None, None, None],
+      [None, None, ':domain', None, None, ':ARG0-of', None, None, None, None, None, None, None, None, None, None],
+      [None, None, None, None, None, None, ':ARG1', None, None, None, None, None, None, None, None, None],
+      [None, None, None, None, None, None, None, None, ':name', ':wiki', None, None, None, None, None, None],
+      [None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None],
+      [None, None, None, None, None, None, None, None, None, ':op1', None, None, None, None, None, None],
+      [None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None],
+      [None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None],
+      [None, None, None, None, None, None, None, None, None, None, ':ARG2', None, ':ARG1-of', None, None, None], 
+      [None, None, None, None, None, None, None, None, None, None, None, None, None, None, ':ARG2', None],
+      [None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None],
+      [None, None, None, None, None, None, None, None, None, None, None, None, None, ':op1', None, ':op2'],
+      [None, None, None, None, None, None, None, None, None, None, None, None, None, None, None, None]]
+    self.assertEqual(training_entry.concepts, expected_concepts)
+    self.assertEqual(training_entry.adjacency_mat, expected_mat)
+
+
+if __name__ == '__main__':
+  absltest.main()

--- a/tests/data_pipeline/training_entry_test.py
+++ b/tests/data_pipeline/training_entry_test.py
@@ -43,8 +43,8 @@ class TrainingEntryTest(absltest.TestCase):
       ('i2', ':instance', 'industry'): [Alignment((3,), prefix='e.')]
     }
     g = penman.Graph(triples, top, epidata)
-    training_entry = TrainingEntry.construct_from_penman(
-      g, unalignment_tolerance=0)
+    training_entry = TrainingEntry(
+      [], g, unalignment_tolerance=0)
     expected_concepts = [
       'root', 'establish-01', 'model', 'industry', 'innovate-01']
     expected_mat = [
@@ -103,8 +103,8 @@ class TrainingEntryTest(absltest.TestCase):
       ('c', ':instance', 'close-10'): [Alignment((5,), prefix='e.')]
     }
     g = penman.Graph(triples, top, epidata)
-    training_entry = TrainingEntry.construct_from_penman(
-      g, unalignment_tolerance=0)
+    training_entry = TrainingEntry(
+      [], g, unalignment_tolerance=0)
     expected_concepts = [
       'root', 'this', 'issue-02', 'recommend-01', 'attract-01', 'close-10', 'attend-02', 'economist'
     ]
@@ -197,8 +197,8 @@ class TrainingEntryTest(absltest.TestCase):
       ('a', ':op2', 'p'): [],
       ('p', ':instance', 'patriotism'): [Alignment((23,), prefix='e.')]}
     g = penman.Graph(triples, top, epidata)
-    training_entry = TrainingEntry.construct_from_penman(
-      g, unalignment_tolerance=1)
+    training_entry = TrainingEntry(
+      [], g, unalignment_tolerance=1)
     expected_concepts = [
       'root', 'more', 'they', 'consider-01', 'person', 'betray-01', 'country',
       '"China"', 'name', '"China"', 'culture', 'tyrannize-01', 'cloak-01',

--- a/tests/data_pipeline/vocab_test.py
+++ b/tests/data_pipeline/vocab_test.py
@@ -1,0 +1,38 @@
+from absl.testing import absltest
+
+from data_pipeline.vocab import build_vocab
+
+
+"""
+Tests for data_pipeline/vocab.py
+Run from project dir with 'python -m tests.data_pipeline.vocab_test'
+"""
+
+class TrainingEntryTest(absltest.TestCase):
+
+  def test_build_vocab_min_freq_1(self):
+    words = [
+      'Ana', 'are', 'mere', 'cuvinte', 'rosii', 'mere', 'pisica', 'are',
+      'portocale', 'are', 'are'
+    ]
+    special_words = ['PAD', 'UNK']
+    min_freq = 1
+    vocab = build_vocab(words, special_words, min_freq)
+    expected_vocab = {'PAD': 0, 'UNK': 1, 'are': 2, 'mere': 3, 'Ana': 4,
+                      'cuvinte': 5, 'rosii': 6, 'pisica': 7, 'portocale': 8}
+    self.assertEqual(vocab, expected_vocab)
+
+  def test_build_vocab_min_freq_2(self):
+    words = [
+      'Ana', 'are', 'mere', 'cuvinte', 'rosii', 'mere', 'pisica', 'are',
+      'portocale', 'are', 'are'
+    ]
+    special_words = ['PAD', 'UNK']
+    min_freq = 2
+    vocab = build_vocab(words, special_words, min_freq)
+    expected_vocab = {'PAD': 0, 'UNK': 1, 'are': 2, 'mere': 3}
+    self.assertEqual(vocab, expected_vocab)
+
+
+if __name__ == '__main__':
+  absltest.main()


### PR DESCRIPTION
This PR creates a first draft of the data pipeline:
* the sentences and amrs with alignements are read from the data files (see definitions.py for data paths)
* the amrs are parsed from string format using the penman package
* the amr in penman format (with the alignments) is used to extract the list of ordered concepts and the adjacency matrix
* a pytorch dataset is implemented, together with a collate function that can be used for batching
  * each batch is a dict of sentences, concepts and adjacency matrices, padded with zeros to have the same shape in the batch and stacked

For now an example of how the dataset can be used is given for the training data and can be run from the project root with:
`python -m data_pipeline.dataset`

This will be removed once more tests are added & the dataset will be used in training.

This PR does not contain:
* obtaining an AMR string from pytorch tensors (concepts & adj mat)