### PR TITLE
Add yacs config file to concept identification

### DIFF
--- a/config.py
+++ b/config.py
@@ -1,0 +1,22 @@
+from yacs.config import CfgNode as CN
+
+_C = CN()
+
+# Configs for Concept Identification.
+_C.CONCEPT_IDENTIFICATION = CN()
+# Configs for LSTM-based Concept Identification.
+_C.CONCEPT_IDENTIFICATION.LSTM_BASED = CN()
+# Embeddings dimension.
+_C.CONCEPT_IDENTIFICATION.LSTM_BASED.EMB_DIM = 50
+# Hidden size.
+_C.CONCEPT_IDENTIFICATION.LSTM_BASED.HIDDEN_SIZE = 40
+# Number of layers.
+_C.CONCEPT_IDENTIFICATION.LSTM_BASED.NUM_LAYERS = 1
+# Configs for Transformer-based Concept Identification.
+_C.CONCEPT_IDENTIFICATION.TRANSF_BASED = CN()
+#TODO: add transformer based configs.
+
+#TODO: add head selection configs.
+
+def get_default_config():
+  return _C.clone()

--- a/configs/example_config.yaml
+++ b/configs/example_config.yaml
@@ -1,0 +1,4 @@
+# This file serves as an example of a config that overwrites the default.
+CONCEPT_IDENTIFICATION:
+  LSTM_BASED:
+    EMB_DIM: 3

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ penman
 absl-py
 torch
 tensorboard
+yacs


### PR DESCRIPTION
With this PR the following changes are done:
1. A config file is loaded instead of using in script constants for concept identification
  * the *yacs* library is used
  * fields in the default config file can be overwritten
     * an example of this is `configs/example_config.yaml` which can be used by calling the train script like: `python train_concept_identification --config=example_config.yaml`
  * this is done to prepare the setup for switching between the lstm based and transformer based solutions for concept identification (just needing to pass in the config object to the model class)
2. The absl flags are used for passing command line arguments to the train script:
  * Some constants in the train script are replaced by absl flags
  * The experiment config file can be passed as a command line argument (with `--config`) 
3. The executed code in the train script was moved to a `main()` function
  * This was needed to be able to use the command line arguments with `absl.flags`
  * This incurred additional changes (like passing the `vocabs` around since the variable was actually a global variable). This should also improve the code quality.